### PR TITLE
Implement Mask struct with full CRUD and creature integration

### DIFF
--- a/i18n/en/data_docs.ftl
+++ b/i18n/en/data_docs.ftl
@@ -321,3 +321,20 @@ return-main-page = return to the main page
 ## Record not found
 record-not-found = Record not found
 record-not-found-explain = The Record you are searching for is not available.
+## Masks
+masks = Masks
+mask = Mask
+new-mask = New Mask
+mask-name = Mask Name
+mask-description = Mask Description
+stat-modifiers = Stat Modifiers
+stat-modifiers-help = Enter delta values (positive or negative) to add to a creature's base stats when this mask is applied. Use 0 for no change.
+apply-mask = Apply Mask
+no-mask = No Mask
+mask-apply-help = Optionally select a mask to apply stat modifiers and add attacks, powers, talents, and maneuvers from the mask template.
+add-mask-items-after-save = After saving, you can add attacks, powers, talents, and maneuvers to this mask.
+created-by = Created by
+no-masks = No masks available yet.
+view-button = View
+delete-warning = This action is permanent and cannot be undone.
+type-name-to-confirm = Type the name to confirm deletion

--- a/i18n/fr/data_docs.ftl
+++ b/i18n/fr/data_docs.ftl
@@ -321,3 +321,20 @@ return-main-page = return to the main page
 ## Record not found
 record-not-found = Record not found
 record-not-found-explain = The Record you are searching for is not available.
+## Masks
+masks = Masques
+mask = Masque
+new-mask = Nouveau Masque
+mask-name = Nom du Masque
+mask-description = Description du Masque
+stat-modifiers = Modificateurs de Statistiques
+stat-modifiers-help = Entrez des valeurs delta (positives ou négatives) à ajouter aux statistiques de base d'une créature lorsque ce masque est appliqué. Utilisez 0 pour aucun changement.
+apply-mask = Appliquer un Masque
+no-mask = Aucun Masque
+mask-apply-help = Sélectionnez optionnellement un masque pour appliquer des modificateurs de statistiques et ajouter des attaques, pouvoirs, talents et manœuvres du modèle de masque.
+add-mask-items-after-save = Après la sauvegarde, vous pouvez ajouter des attaques, pouvoirs, talents et manœuvres à ce masque.
+created-by = Créé par
+no-masks = Aucun masque disponible pour l'instant.
+view-button = Voir
+delete-warning = Cette action est permanente et ne peut pas être annulée.
+type-name-to-confirm = Tapez le nom pour confirmer la suppression

--- a/migrations/2024-04-01-000000_create_masks/down.sql
+++ b/migrations/2024-04-01-000000_create_masks/down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS mask_maneuvers;
+DROP TABLE IF EXISTS mask_talents;
+DROP TABLE IF EXISTS mask_powers;
+DROP TABLE IF EXISTS mask_attacks;
+DROP TABLE IF EXISTS masks;

--- a/migrations/2024-04-01-000000_create_masks/up.sql
+++ b/migrations/2024-04-01-000000_create_masks/up.sql
@@ -1,0 +1,96 @@
+CREATE TABLE IF NOT EXISTS masks (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    creator_id UUID NOT NULL,
+    FOREIGN KEY(creator_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    creator_slug VARCHAR(256) NOT NULL,
+    name VARCHAR(128) NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    -- stat deltas (added to creature base stats when mask is applied)
+    circle_rank INT NOT NULL DEFAULT 0,
+    dexterity INT NOT NULL DEFAULT 0,
+    strength INT NOT NULL DEFAULT 0,
+    constitution INT NOT NULL DEFAULT 0,
+    perception INT NOT NULL DEFAULT 0,
+    willpower INT NOT NULL DEFAULT 0,
+    charisma INT NOT NULL DEFAULT 0,
+    initiative INT NOT NULL DEFAULT 0,
+    pd INT NOT NULL DEFAULT 0,
+    md INT NOT NULL DEFAULT 0,
+    sd INT NOT NULL DEFAULT 0,
+    pa INT NOT NULL DEFAULT 0,
+    ma INT NOT NULL DEFAULT 0,
+    unconsciousness_rating INT NOT NULL DEFAULT 0,
+    death_rating INT NOT NULL DEFAULT 0,
+    wound INT NOT NULL DEFAULT 0,
+    knockdown INT NOT NULL DEFAULT 0,
+    actions INT NOT NULL DEFAULT 0,
+    recovery_rolls INT NOT NULL DEFAULT 0,
+    karma INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS mask_attacks (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    creator_id UUID NOT NULL,
+    FOREIGN KEY(creator_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    mask_id UUID NOT NULL,
+    FOREIGN KEY(mask_id)
+        REFERENCES masks(id) ON DELETE CASCADE,
+    name VARCHAR(128) NOT NULL,
+    action_step INT NOT NULL DEFAULT 9,
+    effect_step INT NOT NULL DEFAULT 9,
+    details TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS mask_powers (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    creator_id UUID NOT NULL,
+    FOREIGN KEY(creator_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    mask_id UUID NOT NULL,
+    FOREIGN KEY(mask_id)
+        REFERENCES masks(id) ON DELETE CASCADE,
+    name VARCHAR(128) NOT NULL,
+    action_type action_types NOT NULL DEFAULT 'Standard',
+    target action_targets NOT NULL DEFAULT 'PhysicalDefense',
+    resisted_by resisted_bys NOT NULL DEFAULT 'Physical',
+    action_step INT NOT NULL DEFAULT 9,
+    effect_step INT,
+    details TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS mask_talents (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    creator_id UUID NOT NULL,
+    FOREIGN KEY(creator_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    mask_id UUID NOT NULL,
+    FOREIGN KEY(mask_id)
+        REFERENCES masks(id) ON DELETE CASCADE,
+    name VARCHAR(128) NOT NULL,
+    action_step INT NOT NULL DEFAULT 9,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS mask_maneuvers (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    creator_id UUID NOT NULL,
+    FOREIGN KEY(creator_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    mask_id UUID NOT NULL,
+    FOREIGN KEY(mask_id)
+        REFERENCES masks(id) ON DELETE CASCADE,
+    name VARCHAR(128) NOT NULL,
+    source VARCHAR(512) NOT NULL DEFAULT '',
+    details TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/src/handlers/creatures.rs
+++ b/src/handlers/creatures.rs
@@ -2,7 +2,7 @@ use actix_web::{web, get, post, Responder, HttpResponse, HttpRequest, ResponseEr
 use actix_identity::Identity;
 use inflector::Inflector;
 
-use crate::{errors::CustomError, generate_basic_context, generate_unique_code, handlers::{CreatureForm, DeleteForm}, models::{Attack, InsertableAttack, InsertablePower, InsertableTalent, Locales, Maneuver, Power, Tags, Talent, User, UserRole}, AppData};
+use crate::{errors::CustomError, generate_basic_context, generate_unique_code, handlers::{CreatureForm, DeleteForm}, models::{Attack, InsertableAttack, InsertablePower, InsertableTalent, Locales, Maneuver, Mask, MaskAttack, MaskPower, MaskTalent, MaskManeuver, Power, Tags, Talent, User, UserRole}, AppData};
 use uuid::Uuid;
 
 use crate::models::{Creature, InsertableCreature, InsertableManeuver};
@@ -34,6 +34,9 @@ pub async fn new_creature_form(
     let creature = InsertableCreature::default(user.id, session_user);
 
     ctx.insert("creature", &creature);
+
+    let masks = Mask::get_all().unwrap_or_default();
+    ctx.insert("masks", &masks);
 
     let rendered = data.tmpl.render("creatures/new_creature_form.html", &ctx).unwrap();
     HttpResponse::Ok().body(rendered)
@@ -142,38 +145,127 @@ pub async fn post_creature(
     if form.npc != None { tags.push(Some(Tags::NPC));};
     if form.other != None { tags.push(Some(Tags::Other));};
 
+    // If a mask is selected, apply its stat deltas to the form values
+    let mask = if let Some(ref mask_id_str) = form.mask_id {
+        if !mask_id_str.is_empty() {
+            if let Ok(mask_uuid) = Uuid::parse_str(mask_id_str) {
+                Mask::get_by_id(&mask_uuid).ok()
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let (dex, str_, con, per, wil, cha, ini, pd, md, sd, pa, ma,
+         ur, dr, wound, kd, actions, rr, karma, circle) = if let Some(ref m) = mask {
+        (
+            form.dexterity + m.dexterity,
+            form.strength + m.strength,
+            form.constitution + m.constitution,
+            form.perception + m.perception,
+            form.willpower + m.willpower,
+            form.charisma + m.charisma,
+            form.initiative + m.initiative,
+            form.pd + m.pd,
+            form.md + m.md,
+            form.sd + m.sd,
+            form.pa + m.pa,
+            form.ma + m.ma,
+            form.unconsciousness_rating + m.unconsciousness_rating,
+            form.death_rating + m.death_rating,
+            form.wound + m.wound,
+            form.knockdown + m.knockdown,
+            form.actions + m.actions,
+            form.recovery_rolls + m.recovery_rolls,
+            form.karma + m.karma,
+            form.circle_rank + m.circle_rank,
+        )
+    } else {
+        (
+            form.dexterity, form.strength, form.constitution, form.perception,
+            form.willpower, form.charisma, form.initiative, form.pd, form.md,
+            form.sd, form.pa, form.ma, form.unconsciousness_rating,
+            form.death_rating, form.wound, form.knockdown, form.actions,
+            form.recovery_rolls, form.karma, form.circle_rank,
+        )
+    };
+
     let new_creature = InsertableCreature::new(
         user.id,
-        user.slug,
+        user.slug.clone(),
         form.name.to_owned(),
         found_in,
         form.rarity.to_owned(),
-        form.circle_rank,
+        circle,
         form.description.to_owned(),
-        form.dexterity,
-        form.strength,
-        form.constitution,
-        form.perception,
-        form.willpower,
-        form.charisma,
-        form.initiative,
-        form.pd,
-        form.md,
-        form.sd,
-        form.pa,
-        form.ma,
-        form.unconsciousness_rating,
-        form.death_rating,
-        form.wound,
-        form.knockdown,
-        form.actions,
+        dex, str_, con, per, wil, cha, ini, pd, md, sd, pa, ma,
+        ur, dr, wound, kd, actions,
         form.movement.to_owned(),
-        form.recovery_rolls,
-        form.karma,
+        rr, karma,
         tags,
-        );
+    );
 
     let creature = Creature::create(&new_creature).expect("Unable to create creature");
+
+    // Apply mask items to the new creature
+    if let Some(ref m) = mask {
+        if let Ok(mask_attacks) = MaskAttack::get_by_mask_id(m.id) {
+            for ma in &mask_attacks {
+                let new_attack = InsertableAttack::new(
+                    user.id,
+                    creature.id,
+                    ma.name.clone(),
+                    ma.action_step,
+                    ma.effect_step,
+                    ma.details.clone(),
+                );
+                Attack::create(&new_attack).expect("Unable to create attack from mask");
+            }
+        }
+        if let Ok(mask_powers) = MaskPower::get_by_mask_id(m.id) {
+            for mp in &mask_powers {
+                let new_power = InsertablePower::new(
+                    user.id,
+                    creature.id,
+                    mp.name.clone(),
+                    mp.action_type,
+                    mp.target,
+                    mp.resisted_by,
+                    mp.action_step,
+                    mp.effect_step,
+                    mp.details.clone(),
+                );
+                Power::create(&new_power).expect("Unable to create power from mask");
+            }
+        }
+        if let Ok(mask_talents) = MaskTalent::get_by_mask_id(m.id) {
+            for mt in &mask_talents {
+                let new_talent = InsertableTalent::new(
+                    user.id,
+                    creature.id,
+                    mt.name.clone(),
+                    mt.action_step,
+                );
+                Talent::create(&new_talent).expect("Unable to create talent from mask");
+            }
+        }
+        if let Ok(mask_maneuvers) = MaskManeuver::get_by_mask_id(m.id) {
+            for mm in &mask_maneuvers {
+                let new_maneuver = InsertableManeuver::new(
+                    user.id,
+                    creature.id,
+                    mm.name.clone(),
+                    mm.source.clone(),
+                    mm.details.clone(),
+                );
+                Maneuver::create(&new_maneuver).expect("Unable to create maneuver from mask");
+            }
+        }
+    }
 
     println!("Saved!");
 
@@ -213,21 +305,24 @@ pub async fn edit_creature(
 
     ctx.insert("creature", &creature);
 
-    if let Ok(data) = r_attacks {
-        ctx.insert("attacks", &data);
+    if let Ok(attacks) = r_attacks {
+        ctx.insert("attacks", &attacks);
     }
 
-    if let Ok(data) = r_powers {
-        ctx.insert("powers", &data);
+    if let Ok(powers) = r_powers {
+        ctx.insert("powers", &powers);
     }
 
-    if let Ok(data) = r_maneuvers {
-        ctx.insert("maneuvers", &data);
+    if let Ok(maneuvers) = r_maneuvers {
+        ctx.insert("maneuvers", &maneuvers);
     }
 
-    if let Ok(data) = r_talents {
-        ctx.insert("talents", &data);
+    if let Ok(talents) = r_talents {
+        ctx.insert("talents", &talents);
     }
+
+    let masks = Mask::get_all().unwrap_or_default();
+    ctx.insert("masks", &masks);
 
     ctx.insert("steps", &data.steps);
 
@@ -295,35 +390,84 @@ pub async fn edit_creature_post(
     if form.other != None { tags.push(Some(Tags::Other));};
 
     
+    // If a mask is selected, apply its stat deltas to the form values
+    let mask = if let Some(ref mask_id_str) = form.mask_id {
+        if !mask_id_str.is_empty() {
+            if let Ok(mask_uuid) = Uuid::parse_str(mask_id_str) {
+                Mask::get_by_id(&mask_uuid).ok()
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let (dex, str_, con, per, wil, cha, ini, edit_pd, edit_md, edit_sd, edit_pa, edit_ma,
+         ur, dr, wound, kd, edit_actions, rr, karma, circle) = if let Some(ref m) = mask {
+        (
+            form.dexterity + m.dexterity,
+            form.strength + m.strength,
+            form.constitution + m.constitution,
+            form.perception + m.perception,
+            form.willpower + m.willpower,
+            form.charisma + m.charisma,
+            form.initiative + m.initiative,
+            form.pd + m.pd,
+            form.md + m.md,
+            form.sd + m.sd,
+            form.pa + m.pa,
+            form.ma + m.ma,
+            form.unconsciousness_rating + m.unconsciousness_rating,
+            form.death_rating + m.death_rating,
+            form.wound + m.wound,
+            form.knockdown + m.knockdown,
+            form.actions + m.actions,
+            form.recovery_rolls + m.recovery_rolls,
+            form.karma + m.karma,
+            form.circle_rank + m.circle_rank,
+        )
+    } else {
+        (
+            form.dexterity, form.strength, form.constitution, form.perception,
+            form.willpower, form.charisma, form.initiative, form.pd, form.md,
+            form.sd, form.pa, form.ma, form.unconsciousness_rating,
+            form.death_rating, form.wound, form.knockdown, form.actions,
+            form.recovery_rolls, form.karma, form.circle_rank,
+        )
+    };
+
     let mut our_creature = Creature {
         id: creature.id,
         creator_id: user.id,
         creator_slug: creature.creator_slug,
         name: form.name.to_owned(),
-        found_in: found_in,
+        found_in,
         rarity: form.rarity.to_owned(),
-        circle_rank: form.circle_rank,
+        circle_rank: circle,
         description: form.description.to_owned(),
-        dexterity: form.dexterity,
-        strength: form.strength,
-        constitution: form.constitution,
-        perception: form.perception,
-        willpower: form.willpower,
-        charisma: form.charisma,
-        initiative: form.initiative,
-        pd: form.pd,
-        md: form.md,
-        sd: form.sd,
-        pa: form.pa,
-        ma: form.ma,
-        unconsciousness_rating: form.unconsciousness_rating,
-        death_rating: form.death_rating,
-        wound: form.wound,
-        knockdown: form.knockdown,
-        actions: form.actions,
+        dexterity: dex,
+        strength: str_,
+        constitution: con,
+        perception: per,
+        willpower: wil,
+        charisma: cha,
+        initiative: ini,
+        pd: edit_pd,
+        md: edit_md,
+        sd: edit_sd,
+        pa: edit_pa,
+        ma: edit_ma,
+        unconsciousness_rating: ur,
+        death_rating: dr,
+        wound,
+        knockdown: kd,
+        actions: edit_actions,
         movement: form.movement.to_owned(),
-        recovery_rolls: form.recovery_rolls,
-        karma: form.karma,
+        recovery_rolls: rr,
+        karma,
         slug,
         image_url: None,
         created_at: creature.created_at,
@@ -331,7 +475,63 @@ pub async fn edit_creature_post(
         tags,
     };
 
-    let creature = Creature::update(&mut our_creature).expect("Unable to create creature");
+    let creature = Creature::update(&mut our_creature).expect("Unable to update creature");
+
+    // Apply mask items to the creature
+    if let Some(ref m) = mask {
+        if let Ok(mask_attacks) = MaskAttack::get_by_mask_id(m.id) {
+            for ma in &mask_attacks {
+                let new_attack = InsertableAttack::new(
+                    user.id,
+                    creature.id,
+                    ma.name.clone(),
+                    ma.action_step,
+                    ma.effect_step,
+                    ma.details.clone(),
+                );
+                Attack::create(&new_attack).expect("Unable to create attack from mask");
+            }
+        }
+        if let Ok(mask_powers) = MaskPower::get_by_mask_id(m.id) {
+            for mp in &mask_powers {
+                let new_power = InsertablePower::new(
+                    user.id,
+                    creature.id,
+                    mp.name.clone(),
+                    mp.action_type,
+                    mp.target,
+                    mp.resisted_by,
+                    mp.action_step,
+                    mp.effect_step,
+                    mp.details.clone(),
+                );
+                Power::create(&new_power).expect("Unable to create power from mask");
+            }
+        }
+        if let Ok(mask_talents) = MaskTalent::get_by_mask_id(m.id) {
+            for mt in &mask_talents {
+                let new_talent = InsertableTalent::new(
+                    user.id,
+                    creature.id,
+                    mt.name.clone(),
+                    mt.action_step,
+                );
+                Talent::create(&new_talent).expect("Unable to create talent from mask");
+            }
+        }
+        if let Ok(mask_maneuvers) = MaskManeuver::get_by_mask_id(m.id) {
+            for mm in &mask_maneuvers {
+                let new_maneuver = InsertableManeuver::new(
+                    user.id,
+                    creature.id,
+                    mm.name.clone(),
+                    mm.source.clone(),
+                    mm.details.clone(),
+                );
+                Maneuver::create(&new_maneuver).expect("Unable to create maneuver from mask");
+            }
+        }
+    }
 
     println!("Saved!");
 

--- a/src/handlers/forms.rs
+++ b/src/handlers/forms.rs
@@ -56,6 +56,8 @@ pub struct CreatureForm {
     pub recovery_rolls: i32,
     pub karma: i32,
     pub image_url: Option<String>,
+    // Optional mask to apply when saving
+    pub mask_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -94,4 +96,64 @@ pub struct ManeuverForm {
 pub struct TalentForm {
     pub name: String,
     pub action_step: i32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MaskForm {
+    pub name: String,
+    pub description: String,
+    // stat deltas
+    pub circle_rank: i32,
+    pub dexterity: i32,
+    pub strength: i32,
+    pub constitution: i32,
+    pub perception: i32,
+    pub willpower: i32,
+    pub charisma: i32,
+    pub initiative: i32,
+    pub pd: i32,
+    pub md: i32,
+    pub sd: i32,
+    pub pa: i32,
+    pub ma: i32,
+    pub unconsciousness_rating: i32,
+    pub death_rating: i32,
+    pub wound: i32,
+    pub knockdown: i32,
+    pub actions: i32,
+    pub recovery_rolls: i32,
+    pub karma: i32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MaskAttackForm {
+    pub name: String,
+    pub action_step: i32,
+    pub effect_step: i32,
+    pub details: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MaskPowerForm {
+    pub name: String,
+    pub action_type: crate::models::ActionType,
+    pub target: crate::models::ActionTarget,
+    pub resisted_by: crate::models::ResistedBy,
+    pub action_step: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effect_step: Option<i32>,
+    pub details: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MaskTalentForm {
+    pub name: String,
+    pub action_step: i32,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MaskManeuverForm {
+    pub name: String,
+    pub source: String,
+    pub details: String,
 }

--- a/src/handlers/masks.rs
+++ b/src/handlers/masks.rs
@@ -1,0 +1,929 @@
+use actix_web::{web, get, post, Responder, HttpResponse, HttpRequest};
+use actix_identity::Identity;
+use uuid::Uuid;
+
+use crate::{
+    generate_basic_context,
+    AppData,
+    handlers::{DeleteForm, MaskForm, MaskAttackForm, MaskPowerForm, MaskTalentForm, MaskManeuverForm},
+    models::{
+        Mask, InsertableMask,
+        MaskAttack, InsertableMaskAttack,
+        MaskPower, InsertableMaskPower,
+        MaskTalent, InsertableMaskTalent,
+        MaskManeuver, InsertableMaskManeuver,
+        User, UserRole,
+    },
+};
+
+// ---- Mask List ----
+
+#[get("/{lang}/masks")]
+pub async fn get_masks(
+    data: web::Data<AppData>,
+    path: web::Path<String>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let lang = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let masks = Mask::get_all().unwrap_or_default();
+    ctx.insert("masks", &masks);
+
+    let rendered = data.tmpl.render("masks/masks.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+// ---- View Mask ----
+
+#[get("/{lang}/mask/{mask_id}")]
+pub async fn get_mask(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let mask = match Mask::get_by_id(&mask_id) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let r_attacks = MaskAttack::get_by_mask_id(mask.id);
+    let r_powers = MaskPower::get_by_mask_id(mask.id);
+    let r_talents = MaskTalent::get_by_mask_id(mask.id);
+    let r_maneuvers = MaskManeuver::get_by_mask_id(mask.id);
+
+    ctx.insert("mask", &mask);
+    ctx.insert("steps", &data.steps);
+
+    if let Ok(data) = r_attacks { ctx.insert("mask_attacks", &data); }
+    if let Ok(data) = r_powers { ctx.insert("mask_powers", &data); }
+    if let Ok(data) = r_talents { ctx.insert("mask_talents", &data); }
+    if let Ok(data) = r_maneuvers { ctx.insert("mask_maneuvers", &data); }
+
+    let rendered = data.tmpl.render("masks/mask.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+// ---- New Mask Form ----
+
+#[get("/{lang}/new_mask_form")]
+pub async fn new_mask_form(
+    data: web::Data<AppData>,
+    path: web::Path<String>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let lang = path.into_inner();
+    let (mut ctx, session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let user = User::get_from_slug(&session_user);
+    if let Err(e) = user {
+        println!("No user found: {:?}. Redirecting", &e);
+        return HttpResponse::Found()
+            .append_header(("Location", format!("/{}/", &lang)))
+            .finish();
+    }
+
+    ctx.insert("steps", &data.steps);
+
+    let rendered = data.tmpl.render("masks/new_mask_form.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+// ---- Post New Mask ----
+
+#[post("/{lang}/post_mask")]
+pub async fn post_mask(
+    _data: web::Data<AppData>,
+    path: web::Path<String>,
+    form: web::Form<MaskForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let lang = path.into_inner();
+    let (_ctx, session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let user = User::get_from_slug(&session_user);
+    if let Err(e) = user {
+        println!("{:?}", &e);
+        return HttpResponse::Found()
+            .append_header(("Location", format!("/{}/", &lang)))
+            .finish();
+    }
+    let user = user.unwrap();
+
+    let new_mask = InsertableMask::new(
+        user.id,
+        user.slug,
+        form.name.to_owned(),
+        form.description.to_owned(),
+        form.circle_rank,
+        form.dexterity,
+        form.strength,
+        form.constitution,
+        form.perception,
+        form.willpower,
+        form.charisma,
+        form.initiative,
+        form.pd,
+        form.md,
+        form.sd,
+        form.pa,
+        form.ma,
+        form.unconsciousness_rating,
+        form.death_rating,
+        form.wound,
+        form.knockdown,
+        form.actions,
+        form.recovery_rolls,
+        form.karma,
+    );
+
+    let mask = Mask::create(&new_mask).expect("Unable to create mask");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, &mask.id)))
+        .finish()
+}
+
+// ---- Edit Mask Form ----
+
+#[get("/{lang}/edit_mask/{mask_id}")]
+pub async fn edit_mask(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (mut ctx, session_user, role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let mask = match Mask::get_by_id(&mask_id) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    if session_user != mask.creator_slug && role != UserRole::Admin {
+        return HttpResponse::Found()
+            .append_header(("Location", format!("/{}/mask/{}", &lang, &mask.id)))
+            .finish();
+    }
+
+    let r_attacks = MaskAttack::get_by_mask_id(mask.id);
+    let r_powers = MaskPower::get_by_mask_id(mask.id);
+    let r_talents = MaskTalent::get_by_mask_id(mask.id);
+    let r_maneuvers = MaskManeuver::get_by_mask_id(mask.id);
+
+    ctx.insert("mask", &mask);
+    ctx.insert("steps", &data.steps);
+
+    if let Ok(data) = r_attacks { ctx.insert("mask_attacks", &data); }
+    if let Ok(data) = r_powers { ctx.insert("mask_powers", &data); }
+    if let Ok(data) = r_talents { ctx.insert("mask_talents", &data); }
+    if let Ok(data) = r_maneuvers { ctx.insert("mask_maneuvers", &data); }
+
+    let rendered = data.tmpl.render("masks/edit_mask_form.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+// ---- Post Edit Mask ----
+
+#[post("/{lang}/edit_mask_post/{mask_id}")]
+pub async fn edit_mask_post(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (_ctx, session_user, role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let mut mask = match Mask::get_by_id(&mask_id) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    if session_user != mask.creator_slug && role != UserRole::Admin {
+        return HttpResponse::Found()
+            .append_header(("Location", format!("/{}/mask/{}", &lang, &mask.id)))
+            .finish();
+    }
+
+    mask.name = form.name.to_owned();
+    mask.description = form.description.to_owned();
+    mask.circle_rank = form.circle_rank;
+    mask.dexterity = form.dexterity;
+    mask.strength = form.strength;
+    mask.constitution = form.constitution;
+    mask.perception = form.perception;
+    mask.willpower = form.willpower;
+    mask.charisma = form.charisma;
+    mask.initiative = form.initiative;
+    mask.pd = form.pd;
+    mask.md = form.md;
+    mask.sd = form.sd;
+    mask.pa = form.pa;
+    mask.ma = form.ma;
+    mask.unconsciousness_rating = form.unconsciousness_rating;
+    mask.death_rating = form.death_rating;
+    mask.wound = form.wound;
+    mask.knockdown = form.knockdown;
+    mask.actions = form.actions;
+    mask.recovery_rolls = form.recovery_rolls;
+    mask.karma = form.karma;
+
+    let updated = Mask::update(&mut mask).expect("Unable to update mask");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, &updated.id)))
+        .finish()
+}
+
+// ---- Delete Mask (GET confirmation) ----
+
+#[get("/{lang}/delete_mask/{mask_id}")]
+pub async fn delete_mask_handler(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+
+    if let Some(id) = id {
+        let (mut ctx, session_user, role, _lang) =
+            generate_basic_context(Some(id), &lang, req.uri().path());
+
+        let mask = match Mask::get_by_id(&mask_id) {
+            Ok(m) => m,
+            Err(e) => {
+                println!("{:?}", e);
+                return HttpResponse::Found()
+                    .append_header(("Location", format!("/{}/masks", &lang)))
+                    .finish();
+            }
+        };
+
+        if session_user != mask.creator_slug && role != UserRole::Admin {
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/mask/{}", &lang, &mask.id)))
+                .finish();
+        }
+
+        ctx.insert("mask", &mask);
+        let rendered = data.tmpl.render("masks/delete_mask.html", &ctx).unwrap();
+        HttpResponse::Ok().body(rendered)
+    } else {
+        HttpResponse::Found()
+            .append_header(("Location", format!("/{}/login", &lang)))
+            .finish()
+    }
+}
+
+// ---- Delete Mask (POST) ----
+
+#[post("/{lang}/delete_mask/{mask_id}")]
+pub async fn delete_mask(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<DeleteForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+
+    if let Some(id) = id {
+        let (_ctx, session_user, role, _lang) =
+            generate_basic_context(Some(id), &lang, req.uri().path());
+
+        let mask = match Mask::get_by_id(&mask_id) {
+            Ok(m) => m,
+            Err(e) => {
+                println!("{:?}", e);
+                return HttpResponse::Found()
+                    .append_header(("Location", format!("/{}/masks", &lang)))
+                    .finish();
+            }
+        };
+
+        if session_user != mask.creator_slug && role != UserRole::Admin {
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/mask/{}", &lang, &mask.id)))
+                .finish();
+        }
+
+        if form.verify.trim() == mask.name {
+            Mask::delete(mask.id).expect("Unable to delete mask");
+            HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish()
+        } else {
+            HttpResponse::Found()
+                .append_header(("Location", format!("/{}/delete_mask/{}", &lang, mask.id)))
+                .finish()
+        }
+    } else {
+        HttpResponse::Found()
+            .append_header(("Location", format!("/{}/login", &lang)))
+            .finish()
+    }
+}
+
+// ---- MaskAttack CRUD ----
+
+#[get("/{lang}/add_mask_attack/{mask_id}")]
+pub async fn add_mask_attack(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    ctx.insert("mask_id", &mask_id);
+    ctx.insert("steps", &data.steps);
+
+    let rendered = data.tmpl.render("masks/add_mask_attack.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+#[post("/{lang}/post_mask_attack/{mask_id}")]
+pub async fn post_mask_attack(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskAttackForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (_ctx, session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let user = User::get_from_slug(&session_user);
+    if let Err(e) = user {
+        println!("{:?}", e);
+        return HttpResponse::Found()
+            .append_header(("Location", format!("/{}/", &lang)))
+            .finish();
+    }
+    let user = user.unwrap();
+
+    let new_attack = InsertableMaskAttack::new(
+        user.id,
+        mask_id,
+        form.name.to_owned(),
+        form.action_step,
+        form.effect_step,
+        form.details.clone(),
+    );
+
+    MaskAttack::create(&new_attack).expect("Unable to create mask attack");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+#[get("/{lang}/edit_mask_attack/{attack_id}")]
+pub async fn edit_mask_attack(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, attack_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let attack = match MaskAttack::get_by_id(&attack_id) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    ctx.insert("mask_attack", &attack);
+    ctx.insert("steps", &data.steps);
+
+    let rendered = data.tmpl.render("masks/edit_mask_attack.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+#[post("/{lang}/edit_mask_attack_post/{attack_id}")]
+pub async fn edit_mask_attack_post(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskAttackForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, attack_id) = path.into_inner();
+    let (_ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let mut attack = match MaskAttack::get_by_id(&attack_id) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let mask_id = attack.mask_id;
+
+    attack.name = form.name.to_owned();
+    attack.action_step = form.action_step;
+    attack.effect_step = form.effect_step;
+    attack.details = form.details.clone();
+
+    MaskAttack::update(&mut attack).expect("Unable to update mask attack");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+#[get("/{lang}/delete_mask_attack/{attack_id}")]
+pub async fn delete_mask_attack(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, attack_id) = path.into_inner();
+    let (_ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let attack = match MaskAttack::get_by_id(&attack_id) {
+        Ok(a) => a,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let mask_id = attack.mask_id;
+    MaskAttack::delete(attack_id).expect("Unable to delete mask attack");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+// ---- MaskPower CRUD ----
+
+#[get("/{lang}/add_mask_power/{mask_id}")]
+pub async fn add_mask_power(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    ctx.insert("mask_id", &mask_id);
+    ctx.insert("steps", &data.steps);
+
+    let rendered = data.tmpl.render("masks/add_mask_power.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+#[post("/{lang}/post_mask_power/{mask_id}")]
+pub async fn post_mask_power(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskPowerForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (_ctx, session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let user = User::get_from_slug(&session_user);
+    if let Err(e) = user {
+        println!("{:?}", e);
+        return HttpResponse::Found()
+            .append_header(("Location", format!("/{}/", &lang)))
+            .finish();
+    }
+    let user = user.unwrap();
+
+    let new_power = InsertableMaskPower::new(
+        user.id,
+        mask_id,
+        form.name.to_owned(),
+        form.action_type,
+        form.target,
+        form.resisted_by,
+        form.action_step,
+        form.effect_step,
+        form.details.clone(),
+    );
+
+    MaskPower::create(&new_power).expect("Unable to create mask power");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+#[get("/{lang}/edit_mask_power/{power_id}")]
+pub async fn edit_mask_power(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, power_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let power = match MaskPower::get_by_id(&power_id) {
+        Ok(p) => p,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    ctx.insert("mask_power", &power);
+    ctx.insert("steps", &data.steps);
+
+    let rendered = data.tmpl.render("masks/edit_mask_power.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+#[post("/{lang}/edit_mask_power_post/{power_id}")]
+pub async fn edit_mask_power_post(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskPowerForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, power_id) = path.into_inner();
+    let (_ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let mut power = match MaskPower::get_by_id(&power_id) {
+        Ok(p) => p,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let mask_id = power.mask_id;
+
+    power.name = form.name.to_owned();
+    power.action_type = form.action_type;
+    power.target = form.target;
+    power.resisted_by = form.resisted_by;
+    power.action_step = form.action_step;
+    power.effect_step = form.effect_step;
+    power.details = form.details.clone();
+
+    MaskPower::update(&mut power).expect("Unable to update mask power");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+#[get("/{lang}/delete_mask_power/{power_id}")]
+pub async fn delete_mask_power(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, power_id) = path.into_inner();
+    let (_ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let power = match MaskPower::get_by_id(&power_id) {
+        Ok(p) => p,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let mask_id = power.mask_id;
+    MaskPower::delete(power_id).expect("Unable to delete mask power");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+// ---- MaskTalent CRUD ----
+
+#[get("/{lang}/add_mask_talent/{mask_id}")]
+pub async fn add_mask_talent(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    ctx.insert("mask_id", &mask_id);
+    ctx.insert("steps", &data.steps);
+
+    let rendered = data.tmpl.render("masks/add_mask_talent.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+#[post("/{lang}/post_mask_talent/{mask_id}")]
+pub async fn post_mask_talent(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskTalentForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (_ctx, session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let user = User::get_from_slug(&session_user);
+    if let Err(e) = user {
+        println!("{:?}", e);
+        return HttpResponse::Found()
+            .append_header(("Location", format!("/{}/", &lang)))
+            .finish();
+    }
+    let user = user.unwrap();
+
+    let new_talent = InsertableMaskTalent::new(
+        user.id,
+        mask_id,
+        form.name.to_owned(),
+        form.action_step,
+    );
+
+    MaskTalent::create(&new_talent).expect("Unable to create mask talent");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+#[get("/{lang}/edit_mask_talent/{talent_id}")]
+pub async fn edit_mask_talent(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, talent_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let talent = match MaskTalent::get_by_id(&talent_id) {
+        Ok(t) => t,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    ctx.insert("mask_talent", &talent);
+    ctx.insert("steps", &data.steps);
+
+    let rendered = data.tmpl.render("masks/edit_mask_talent.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+#[post("/{lang}/edit_mask_talent_post/{talent_id}")]
+pub async fn edit_mask_talent_post(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskTalentForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, talent_id) = path.into_inner();
+    let (_ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let mut talent = match MaskTalent::get_by_id(&talent_id) {
+        Ok(t) => t,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let mask_id = talent.mask_id;
+
+    talent.name = form.name.to_owned();
+    talent.action_step = form.action_step;
+
+    MaskTalent::update(&mut talent).expect("Unable to update mask talent");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+#[get("/{lang}/delete_mask_talent/{talent_id}")]
+pub async fn delete_mask_talent(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, talent_id) = path.into_inner();
+    let (_ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let talent = match MaskTalent::get_by_id(&talent_id) {
+        Ok(t) => t,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let mask_id = talent.mask_id;
+    MaskTalent::delete(talent_id).expect("Unable to delete mask talent");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+// ---- MaskManeuver CRUD ----
+
+#[get("/{lang}/add_mask_maneuver/{mask_id}")]
+pub async fn add_mask_maneuver(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    ctx.insert("mask_id", &mask_id);
+
+    let rendered = data.tmpl.render("masks/add_mask_maneuver.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+#[post("/{lang}/post_mask_maneuver/{mask_id}")]
+pub async fn post_mask_maneuver(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskManeuverForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, mask_id) = path.into_inner();
+    let (_ctx, session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let user = User::get_from_slug(&session_user);
+    if let Err(e) = user {
+        println!("{:?}", e);
+        return HttpResponse::Found()
+            .append_header(("Location", format!("/{}/", &lang)))
+            .finish();
+    }
+    let user = user.unwrap();
+
+    let new_maneuver = InsertableMaskManeuver::new(
+        user.id,
+        mask_id,
+        form.name.to_owned(),
+        form.source.to_owned(),
+        form.details.to_owned(),
+    );
+
+    MaskManeuver::create(&new_maneuver).expect("Unable to create mask maneuver");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+#[get("/{lang}/edit_mask_maneuver/{maneuver_id}")]
+pub async fn edit_mask_maneuver(
+    data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, maneuver_id) = path.into_inner();
+    let (mut ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let maneuver = match MaskManeuver::get_by_id(&maneuver_id) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    ctx.insert("mask_maneuver", &maneuver);
+
+    let rendered = data.tmpl.render("masks/edit_mask_maneuver.html", &ctx).unwrap();
+    HttpResponse::Ok().body(rendered)
+}
+
+#[post("/{lang}/edit_mask_maneuver_post/{maneuver_id}")]
+pub async fn edit_mask_maneuver_post(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    form: web::Form<MaskManeuverForm>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, maneuver_id) = path.into_inner();
+    let (_ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let mut maneuver = match MaskManeuver::get_by_id(&maneuver_id) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let mask_id = maneuver.mask_id;
+
+    maneuver.name = form.name.to_owned();
+    maneuver.source = form.source.to_owned();
+    maneuver.details = form.details.to_owned();
+
+    MaskManeuver::update(&mut maneuver).expect("Unable to update mask maneuver");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}
+
+#[get("/{lang}/delete_mask_maneuver/{maneuver_id}")]
+pub async fn delete_mask_maneuver(
+    _data: web::Data<AppData>,
+    path: web::Path<(String, Uuid)>,
+    id: Option<Identity>,
+    req: HttpRequest,
+) -> impl Responder {
+    let (lang, maneuver_id) = path.into_inner();
+    let (_ctx, _session_user, _role, _lang) = generate_basic_context(id, &lang, req.uri().path());
+
+    let maneuver = match MaskManeuver::get_by_id(&maneuver_id) {
+        Ok(m) => m,
+        Err(e) => {
+            println!("{:?}", e);
+            return HttpResponse::Found()
+                .append_header(("Location", format!("/{}/masks", &lang)))
+                .finish();
+        }
+    };
+
+    let mask_id = maneuver.mask_id;
+    MaskManeuver::delete(maneuver_id).expect("Unable to delete mask maneuver");
+
+    HttpResponse::Found()
+        .append_header(("Location", format!("/{}/edit_mask/{}", &lang, mask_id)))
+        .finish()
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -11,6 +11,7 @@ pub mod attacks;
 pub mod powers;
 pub mod maneuver;
 pub mod talents;
+pub mod masks;
 
 pub use base::*;
 pub use routes::configure_services;
@@ -25,3 +26,4 @@ pub use attacks::*;
 pub use powers::*;
 pub use maneuver::*;
 pub use talents::*;
+pub use masks::*;

--- a/src/handlers/routes.rs
+++ b/src/handlers/routes.rs
@@ -98,6 +98,36 @@ use crate::handlers::{
     edit_talent,
     edit_talent_post,
     delete_talent,
+
+    // masks
+    get_mask,
+    get_masks,
+    new_mask_form,
+    post_mask,
+    edit_mask,
+    edit_mask_post,
+    delete_mask_handler,
+    delete_mask,
+    add_mask_attack,
+    post_mask_attack,
+    edit_mask_attack,
+    edit_mask_attack_post,
+    delete_mask_attack,
+    add_mask_power,
+    post_mask_power,
+    edit_mask_power,
+    edit_mask_power_post,
+    delete_mask_power,
+    add_mask_talent,
+    post_mask_talent,
+    edit_mask_talent,
+    edit_mask_talent_post,
+    delete_mask_talent,
+    add_mask_maneuver,
+    post_mask_maneuver,
+    edit_mask_maneuver,
+    edit_mask_maneuver_post,
+    delete_mask_maneuver,
 };
 
 pub fn configure_services(config: &mut web::ServiceConfig) {
@@ -197,5 +227,35 @@ pub fn configure_services(config: &mut web::ServiceConfig) {
     config.service(edit_talent);
     config.service(edit_talent_post);
     config.service(delete_talent);
+
+    // masks
+    config.service(get_masks);
+    config.service(get_mask);
+    config.service(new_mask_form);
+    config.service(post_mask);
+    config.service(edit_mask);
+    config.service(edit_mask_post);
+    config.service(delete_mask_handler);
+    config.service(delete_mask);
+    config.service(add_mask_attack);
+    config.service(post_mask_attack);
+    config.service(edit_mask_attack);
+    config.service(edit_mask_attack_post);
+    config.service(delete_mask_attack);
+    config.service(add_mask_power);
+    config.service(post_mask_power);
+    config.service(edit_mask_power);
+    config.service(edit_mask_power_post);
+    config.service(delete_mask_power);
+    config.service(add_mask_talent);
+    config.service(post_mask_talent);
+    config.service(edit_mask_talent);
+    config.service(edit_mask_talent_post);
+    config.service(delete_mask_talent);
+    config.service(add_mask_maneuver);
+    config.service(post_mask_maneuver);
+    config.service(edit_mask_maneuver);
+    config.service(edit_mask_maneuver_post);
+    config.service(delete_mask_maneuver);
 
 }

--- a/src/models/mask.rs
+++ b/src/models/mask.rs
@@ -1,29 +1,569 @@
 use chrono::NaiveDateTime;
 use uuid::Uuid;
 
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug)]
+use crate::errors::CustomError;
+use crate::database::connection;
+use crate::schema::{masks, mask_attacks, mask_powers, mask_talents, mask_maneuvers};
+use crate::models::{ActionTarget, ActionType, ResistedBy};
+
+use diesel::prelude::*;
+use diesel::{RunQueryDsl, QueryDsl};
+
+// ---- Mask ----
+
+#[derive(Serialize, Deserialize, Queryable, AsChangeset, Insertable, Debug, Identifiable, Clone)]
+#[diesel(table_name = masks)]
 pub struct Mask {
-    pub uuid: Uuid,
+    pub id: Uuid,
+    pub creator_id: Uuid,
+    pub creator_slug: String,
     pub name: String,
-    pub circle: i32,
-    pub dex: i32,
-    pub str: i32,
-    pub con: i32,
-    pub per: i32,
-    pub wil: i32,
-    pub cha: i32,
+    pub description: String,
+    // stat deltas - added to creature's current stats when applied
+    pub circle_rank: i32,
+    pub dexterity: i32,
+    pub strength: i32,
+    pub constitution: i32,
+    pub perception: i32,
+    pub willpower: i32,
+    pub charisma: i32,
     pub initiative: i32,
     pub pd: i32,
     pub md: i32,
     pub sd: i32,
     pub pa: i32,
     pub ma: i32,
-    pub unconscious_rating: i32,
+    pub unconsciousness_rating: i32,
     pub death_rating: i32,
     pub wound: i32,
     pub knockdown: i32,
     pub actions: i32,
+    pub recovery_rolls: i32,
+    pub karma: i32,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
+}
+
+impl Mask {
+    pub fn create(data: &InsertableMask) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::insert_into(masks::table)
+            .values(data)
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_id(id: &Uuid) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = masks::table
+            .filter(masks::id.eq(id))
+            .first(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_all() -> Result<Vec<Self>, CustomError> {
+        let mut conn = connection()?;
+        let res = masks::table
+            .order(masks::name.asc())
+            .load::<Mask>(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_creator(creator_id: &Uuid) -> Result<Vec<Self>, CustomError> {
+        let mut conn = connection()?;
+        let res = masks::table
+            .filter(masks::creator_id.eq(creator_id))
+            .order(masks::name.asc())
+            .load::<Mask>(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn update(&mut self) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        self.updated_at = chrono::Utc::now().naive_utc();
+        let res = diesel::update(masks::table)
+            .filter(masks::id.eq(&self.id))
+            .set(self.clone())
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn delete(id: Uuid) -> Result<usize, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::delete(masks::table.filter(masks::id.eq(id)))
+            .execute(&mut conn)?;
+        Ok(res)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Insertable)]
+#[diesel(table_name = masks)]
+pub struct InsertableMask {
+    pub creator_id: Uuid,
+    pub creator_slug: String,
+    pub name: String,
+    pub description: String,
+    pub circle_rank: i32,
+    pub dexterity: i32,
+    pub strength: i32,
+    pub constitution: i32,
+    pub perception: i32,
+    pub willpower: i32,
+    pub charisma: i32,
+    pub initiative: i32,
+    pub pd: i32,
+    pub md: i32,
+    pub sd: i32,
+    pub pa: i32,
+    pub ma: i32,
+    pub unconsciousness_rating: i32,
+    pub death_rating: i32,
+    pub wound: i32,
+    pub knockdown: i32,
+    pub actions: i32,
+    pub recovery_rolls: i32,
+    pub karma: i32,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl InsertableMask {
+    pub fn new(
+        creator_id: Uuid,
+        creator_slug: String,
+        name: String,
+        description: String,
+        circle_rank: i32,
+        dexterity: i32,
+        strength: i32,
+        constitution: i32,
+        perception: i32,
+        willpower: i32,
+        charisma: i32,
+        initiative: i32,
+        pd: i32,
+        md: i32,
+        sd: i32,
+        pa: i32,
+        ma: i32,
+        unconsciousness_rating: i32,
+        death_rating: i32,
+        wound: i32,
+        knockdown: i32,
+        actions: i32,
+        recovery_rolls: i32,
+        karma: i32,
+    ) -> Self {
+        let today = chrono::Utc::now().naive_utc();
+        InsertableMask {
+            creator_id,
+            creator_slug,
+            name,
+            description,
+            circle_rank,
+            dexterity,
+            strength,
+            constitution,
+            perception,
+            willpower,
+            charisma,
+            initiative,
+            pd,
+            md,
+            sd,
+            pa,
+            ma,
+            unconsciousness_rating,
+            death_rating,
+            wound,
+            knockdown,
+            actions,
+            recovery_rolls,
+            karma,
+            created_at: today,
+            updated_at: today,
+        }
+    }
+}
+
+// ---- MaskAttack ----
+
+#[derive(Serialize, Deserialize, Queryable, AsChangeset, Insertable, Debug, Identifiable, Clone)]
+#[diesel(table_name = mask_attacks)]
+pub struct MaskAttack {
+    pub id: Uuid,
+    pub creator_id: Uuid,
+    pub mask_id: Uuid,
+    pub name: String,
+    pub action_step: i32,
+    pub effect_step: i32,
+    pub details: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl MaskAttack {
+    pub fn create(data: &InsertableMaskAttack) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::insert_into(mask_attacks::table)
+            .values(data)
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_id(id: &Uuid) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = mask_attacks::table
+            .filter(mask_attacks::id.eq(id))
+            .first(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_mask_id(mask_id: Uuid) -> Result<Vec<Self>, CustomError> {
+        let mut conn = connection()?;
+        let res = mask_attacks::table
+            .filter(mask_attacks::mask_id.eq(mask_id))
+            .load::<MaskAttack>(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn update(&mut self) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        self.updated_at = chrono::Utc::now().naive_utc();
+        let res = diesel::update(mask_attacks::table)
+            .filter(mask_attacks::id.eq(&self.id))
+            .set(self.clone())
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn delete(id: Uuid) -> Result<usize, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::delete(mask_attacks::table.filter(mask_attacks::id.eq(id)))
+            .execute(&mut conn)?;
+        Ok(res)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Insertable)]
+#[diesel(table_name = mask_attacks)]
+pub struct InsertableMaskAttack {
+    pub creator_id: Uuid,
+    pub mask_id: Uuid,
+    pub name: String,
+    pub action_step: i32,
+    pub effect_step: i32,
+    pub details: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl InsertableMaskAttack {
+    pub fn new(
+        creator_id: Uuid,
+        mask_id: Uuid,
+        name: String,
+        action_step: i32,
+        effect_step: i32,
+        details: Option<String>,
+    ) -> Self {
+        let today = chrono::Utc::now().naive_utc();
+        InsertableMaskAttack {
+            creator_id,
+            mask_id,
+            name,
+            action_step,
+            effect_step,
+            details,
+            created_at: today,
+            updated_at: today,
+        }
+    }
+}
+
+// ---- MaskPower ----
+
+#[derive(Serialize, Deserialize, Queryable, AsChangeset, Insertable, Debug, Identifiable, Clone)]
+#[diesel(table_name = mask_powers)]
+pub struct MaskPower {
+    pub id: Uuid,
+    pub creator_id: Uuid,
+    pub mask_id: Uuid,
+    pub name: String,
+    pub action_type: ActionType,
+    pub target: ActionTarget,
+    pub resisted_by: ResistedBy,
+    pub action_step: i32,
+    pub effect_step: Option<i32>,
+    pub details: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl MaskPower {
+    pub fn create(data: &InsertableMaskPower) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::insert_into(mask_powers::table)
+            .values(data)
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_id(id: &Uuid) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = mask_powers::table
+            .filter(mask_powers::id.eq(id))
+            .first(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_mask_id(mask_id: Uuid) -> Result<Vec<Self>, CustomError> {
+        let mut conn = connection()?;
+        let res = mask_powers::table
+            .filter(mask_powers::mask_id.eq(mask_id))
+            .load::<MaskPower>(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn update(&mut self) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        self.updated_at = chrono::Utc::now().naive_utc();
+        let res = diesel::update(mask_powers::table)
+            .filter(mask_powers::id.eq(&self.id))
+            .set(self.clone())
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn delete(id: Uuid) -> Result<usize, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::delete(mask_powers::table.filter(mask_powers::id.eq(id)))
+            .execute(&mut conn)?;
+        Ok(res)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Insertable)]
+#[diesel(table_name = mask_powers)]
+pub struct InsertableMaskPower {
+    pub creator_id: Uuid,
+    pub mask_id: Uuid,
+    pub name: String,
+    pub action_type: ActionType,
+    pub target: ActionTarget,
+    pub resisted_by: ResistedBy,
+    pub action_step: i32,
+    pub effect_step: Option<i32>,
+    pub details: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl InsertableMaskPower {
+    pub fn new(
+        creator_id: Uuid,
+        mask_id: Uuid,
+        name: String,
+        action_type: ActionType,
+        target: ActionTarget,
+        resisted_by: ResistedBy,
+        action_step: i32,
+        effect_step: Option<i32>,
+        details: Option<String>,
+    ) -> Self {
+        let today = chrono::Utc::now().naive_utc();
+        InsertableMaskPower {
+            creator_id,
+            mask_id,
+            name,
+            action_type,
+            target,
+            resisted_by,
+            action_step,
+            effect_step,
+            details,
+            created_at: today,
+            updated_at: today,
+        }
+    }
+}
+
+// ---- MaskTalent ----
+
+#[derive(Serialize, Deserialize, Queryable, AsChangeset, Insertable, Debug, Identifiable, Clone)]
+#[diesel(table_name = mask_talents)]
+pub struct MaskTalent {
+    pub id: Uuid,
+    pub creator_id: Uuid,
+    pub mask_id: Uuid,
+    pub name: String,
+    pub action_step: i32,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl MaskTalent {
+    pub fn create(data: &InsertableMaskTalent) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::insert_into(mask_talents::table)
+            .values(data)
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_id(id: &Uuid) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = mask_talents::table
+            .filter(mask_talents::id.eq(id))
+            .first(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_mask_id(mask_id: Uuid) -> Result<Vec<Self>, CustomError> {
+        let mut conn = connection()?;
+        let res = mask_talents::table
+            .filter(mask_talents::mask_id.eq(mask_id))
+            .load::<MaskTalent>(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn update(&mut self) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        self.updated_at = chrono::Utc::now().naive_utc();
+        let res = diesel::update(mask_talents::table)
+            .filter(mask_talents::id.eq(&self.id))
+            .set(self.clone())
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn delete(id: Uuid) -> Result<usize, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::delete(mask_talents::table.filter(mask_talents::id.eq(id)))
+            .execute(&mut conn)?;
+        Ok(res)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Insertable)]
+#[diesel(table_name = mask_talents)]
+pub struct InsertableMaskTalent {
+    pub creator_id: Uuid,
+    pub mask_id: Uuid,
+    pub name: String,
+    pub action_step: i32,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl InsertableMaskTalent {
+    pub fn new(
+        creator_id: Uuid,
+        mask_id: Uuid,
+        name: String,
+        action_step: i32,
+    ) -> Self {
+        let today = chrono::Utc::now().naive_utc();
+        InsertableMaskTalent {
+            creator_id,
+            mask_id,
+            name,
+            action_step,
+            created_at: today,
+            updated_at: today,
+        }
+    }
+}
+
+// ---- MaskManeuver ----
+
+#[derive(Serialize, Deserialize, Queryable, AsChangeset, Insertable, Debug, Identifiable, Clone)]
+#[diesel(table_name = mask_maneuvers)]
+pub struct MaskManeuver {
+    pub id: Uuid,
+    pub creator_id: Uuid,
+    pub mask_id: Uuid,
+    pub name: String,
+    pub source: String,
+    pub details: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl MaskManeuver {
+    pub fn create(data: &InsertableMaskManeuver) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::insert_into(mask_maneuvers::table)
+            .values(data)
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_id(id: &Uuid) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        let res = mask_maneuvers::table
+            .filter(mask_maneuvers::id.eq(id))
+            .first(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn get_by_mask_id(mask_id: Uuid) -> Result<Vec<Self>, CustomError> {
+        let mut conn = connection()?;
+        let res = mask_maneuvers::table
+            .filter(mask_maneuvers::mask_id.eq(mask_id))
+            .load::<MaskManeuver>(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn update(&mut self) -> Result<Self, CustomError> {
+        let mut conn = connection()?;
+        self.updated_at = chrono::Utc::now().naive_utc();
+        let res = diesel::update(mask_maneuvers::table)
+            .filter(mask_maneuvers::id.eq(&self.id))
+            .set(self.clone())
+            .get_result(&mut conn)?;
+        Ok(res)
+    }
+
+    pub fn delete(id: Uuid) -> Result<usize, CustomError> {
+        let mut conn = connection()?;
+        let res = diesel::delete(mask_maneuvers::table.filter(mask_maneuvers::id.eq(id)))
+            .execute(&mut conn)?;
+        Ok(res)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Insertable)]
+#[diesel(table_name = mask_maneuvers)]
+pub struct InsertableMaskManeuver {
+    pub creator_id: Uuid,
+    pub mask_id: Uuid,
+    pub name: String,
+    pub source: String,
+    pub details: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+impl InsertableMaskManeuver {
+    pub fn new(
+        creator_id: Uuid,
+        mask_id: Uuid,
+        name: String,
+        source: String,
+        details: String,
+    ) -> Self {
+        let today = chrono::Utc::now().naive_utc();
+        InsertableMaskManeuver {
+            creator_id,
+            mask_id,
+            name,
+            source,
+            details,
+            created_at: today,
+            updated_at: today,
+        }
+    }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,6 +6,7 @@ mod attack;
 mod power;
 mod maneuver;
 mod talent;
+mod mask;
 
 
 pub use user::*;
@@ -16,3 +17,4 @@ pub use attack::*;
 pub use power::*;
 pub use maneuver::*;
 pub use talent::*;
+pub use mask::*;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -31,6 +31,106 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    mask_attacks (id) {
+        id -> Uuid,
+        creator_id -> Uuid,
+        mask_id -> Uuid,
+        #[max_length = 128]
+        name -> Varchar,
+        action_step -> Int4,
+        effect_step -> Int4,
+        details -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::ActionTypes;
+    use super::sql_types::ActionTargets;
+    use super::sql_types::ResistedBys;
+
+    mask_powers (id) {
+        id -> Uuid,
+        creator_id -> Uuid,
+        mask_id -> Uuid,
+        #[max_length = 128]
+        name -> Varchar,
+        action_type -> ActionTypes,
+        target -> ActionTargets,
+        resisted_by -> ResistedBys,
+        action_step -> Int4,
+        effect_step -> Nullable<Int4>,
+        details -> Nullable<Text>,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    mask_talents (id) {
+        id -> Uuid,
+        creator_id -> Uuid,
+        mask_id -> Uuid,
+        #[max_length = 128]
+        name -> Varchar,
+        action_step -> Int4,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    mask_maneuvers (id) {
+        id -> Uuid,
+        creator_id -> Uuid,
+        mask_id -> Uuid,
+        #[max_length = 128]
+        name -> Varchar,
+        #[max_length = 512]
+        source -> Varchar,
+        details -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    masks (id) {
+        id -> Uuid,
+        creator_id -> Uuid,
+        #[max_length = 256]
+        creator_slug -> Varchar,
+        #[max_length = 128]
+        name -> Varchar,
+        description -> Text,
+        circle_rank -> Int4,
+        dexterity -> Int4,
+        strength -> Int4,
+        constitution -> Int4,
+        perception -> Int4,
+        willpower -> Int4,
+        charisma -> Int4,
+        initiative -> Int4,
+        pd -> Int4,
+        md -> Int4,
+        sd -> Int4,
+        pa -> Int4,
+        ma -> Int4,
+        unconsciousness_rating -> Int4,
+        death_rating -> Int4,
+        wound -> Int4,
+        knockdown -> Int4,
+        actions -> Int4,
+        recovery_rolls -> Int4,
+        karma -> Int4,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     attacks (id) {
         id -> Uuid,
         creator_id -> Uuid,
@@ -196,12 +296,26 @@ diesel::joinable!(powers -> creatures (creature_id));
 diesel::joinable!(powers -> users (creator_id));
 diesel::joinable!(talents -> creatures (creature_id));
 diesel::joinable!(talents -> users (creator_id));
+diesel::joinable!(masks -> users (creator_id));
+diesel::joinable!(mask_attacks -> masks (mask_id));
+diesel::joinable!(mask_attacks -> users (creator_id));
+diesel::joinable!(mask_powers -> masks (mask_id));
+diesel::joinable!(mask_powers -> users (creator_id));
+diesel::joinable!(mask_talents -> masks (mask_id));
+diesel::joinable!(mask_talents -> users (creator_id));
+diesel::joinable!(mask_maneuvers -> masks (mask_id));
+diesel::joinable!(mask_maneuvers -> users (creator_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     attacks,
     creatures,
     email_verification_code,
     maneuvers,
+    mask_attacks,
+    mask_maneuvers,
+    mask_powers,
+    mask_talents,
+    masks,
     password_reset_token,
     powers,
     talents,

--- a/templates/base.html
+++ b/templates/base.html
@@ -361,6 +361,10 @@
                     <a class="nav-link" href="/{{ lang }}/new_creature_form">{{ fluent(key="create-creature", lang=lang )}}<span class="sr-only"></span></a>
                 </li>
 
+                <li class="nav-item">
+                    <a class="nav-link" href="/{{ lang }}/masks">{{ fluent(key="masks", lang=lang )}}<span class="sr-only"></span></a>
+                </li>
+
             <!-- Dropdown Locations -->
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="LocationDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/templates/creatures/edit_creature_form.html
+++ b/templates/creatures/edit_creature_form.html
@@ -304,6 +304,22 @@
         </ul>
     </div>
     
+    {% if masks %}
+    <div class="row mb-3">
+        <hr>
+        <div>
+            <label for="mask_select">{{ fluent(key="apply-mask", lang=lang) }}</label>
+            <select class="form-select" name="mask_id" id="mask_select">
+                <option value="">-- {{ fluent(key="no-mask", lang=lang) }} --</option>
+                {% for mask in masks %}
+                <option value="{{ mask.id }}">{{ mask.name }}{% if mask.description %} - {{ mask.description | truncate(length=60) }}{% endif %}</option>
+                {% endfor %}
+            </select>
+            <small class="form-text text-muted">{{ fluent(key="mask-apply-help", lang=lang) }}</small>
+        </div>
+    </div>
+    {% endif %}
+
     {% if session_user != "" %}
     <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang )}}</button>
     <a class="btn btn-info" href="/{{ lang }}/creature/view/{{ creature.slug }}">{{ fluent(key="cancel-button", lang=lang )}}</a>

--- a/templates/creatures/new_creature_form.html
+++ b/templates/creatures/new_creature_form.html
@@ -333,6 +333,22 @@
         </ul>
     </div>
     
+    {% if masks %}
+    <div class="row mb-3">
+        <hr>
+        <div>
+            <label for="mask_select">{{ fluent(key="apply-mask", lang=lang) }}</label>
+            <select class="form-select" name="mask_id" id="mask_select">
+                <option value="">-- {{ fluent(key="no-mask", lang=lang) }} --</option>
+                {% for mask in masks %}
+                <option value="{{ mask.id }}">{{ mask.name }}{% if mask.description %} - {{ mask.description | truncate(length=60) }}{% endif %}</option>
+                {% endfor %}
+            </select>
+            <small class="form-text text-muted">{{ fluent(key="mask-apply-help", lang=lang) }}</small>
+        </div>
+    </div>
+    {% endif %}
+
     {% if session_user != "" %}
     <button class="btn btn-primary" type="submit">Save</button>
     <a class="btn btn-info" href="/{{ lang }}/creature/{{ creature.slug }}">Cancel</a>

--- a/templates/masks/add_mask_attack.html
+++ b/templates/masks/add_mask_attack.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h2>{{ fluent(key="add-an-attack", lang=lang) }}</h2>
+    <form action="/{{ lang }}/post_mask_attack/{{ mask_id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="creature-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" placeholder="Attack name..." required>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="action-step", lang=lang) }}</label>
+            <select class="form-select" name="action_step">
+                {% for step in steps %}
+                <option value="{{ loop.index }}">{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="effect-step", lang=lang) }}</label>
+            <select class="form-select" name="effect_step">
+                {% for step in steps %}
+                <option value="{{ loop.index }}">{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="details", lang=lang) }}</label>
+            <textarea class="form-control" name="details" rows="2"></textarea>
+        </div>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/edit_mask/{{ mask_id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/add_mask_maneuver.html
+++ b/templates/masks/add_mask_maneuver.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h2>Add a Maneuver</h2>
+    <form action="/{{ lang }}/post_mask_maneuver/{{ mask_id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="creature-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" placeholder="Maneuver name..." required>
+        </div>
+        <div class="mb-3">
+            <label>Source</label>
+            <input class="form-control" type="text" name="source" placeholder="Source book..." required>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="details", lang=lang) }}</label>
+            <textarea class="form-control" name="details" rows="3" required></textarea>
+        </div>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/edit_mask/{{ mask_id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/add_mask_power.html
+++ b/templates/masks/add_mask_power.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h2>{{ fluent(key="add-power-ability-spell", lang=lang) }}</h2>
+    <form action="/{{ lang }}/post_mask_power/{{ mask_id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="creature-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" placeholder="Power name..." required>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="action-type", lang=lang) }}</label>
+            <select class="form-select" name="action_type">
+                <option value="Free">Free</option>
+                <option value="Simple">Simple</option>
+                <option selected value="Standard">Standard</option>
+                <option value="Move">Move</option>
+                <option value="Ritual">Ritual</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="target", lang=lang) }}</label>
+            <select class="form-select" name="target">
+                <option selected value="PhysicalDefense">Physical Defense</option>
+                <option value="MysticDefense">Mystic Defense</option>
+                <option value="SocialDefense">Social Defense</option>
+                <option value="TN6">TN 6</option>
+                <option value="TN10">TN 10</option>
+                <option value="Other">Other</option>
+                <option value="NotApplicable">Not Applicable</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="resisted-by", lang=lang) }}</label>
+            <select class="form-select" name="resisted_by">
+                <option selected value="Physical">Physical</option>
+                <option value="Mystic">Mystic</option>
+                <option value="Other">Other</option>
+                <option value="NotApplicable">Not Applicable</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="action-step", lang=lang) }}</label>
+            <select class="form-select" name="action_step">
+                {% for step in steps %}
+                <option value="{{ loop.index }}">{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="effect-step", lang=lang) }}</label>
+            <select class="form-select" name="effect_step">
+                <option value="">None</option>
+                {% for step in steps %}
+                <option value="{{ loop.index }}">{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="details", lang=lang) }}</label>
+            <textarea class="form-control" name="details" rows="2"></textarea>
+        </div>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/edit_mask/{{ mask_id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/add_mask_talent.html
+++ b/templates/masks/add_mask_talent.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h2>{{ fluent(key="add-a-talent", lang=lang) }}</h2>
+    <form action="/{{ lang }}/post_mask_talent/{{ mask_id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="creature-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" placeholder="Talent name..." required>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="action-step", lang=lang) }}</label>
+            <select class="form-select" name="action_step">
+                {% for step in steps %}
+                <option value="{{ loop.index }}">{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/edit_mask/{{ mask_id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/delete_mask.html
+++ b/templates/masks/delete_mask.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h1>{{ fluent(key="delete-button", lang=lang) }}: {{ mask.name }}</h1>
+    <p class="text-danger">{{ fluent(key="delete-warning", lang=lang) }}</p>
+
+    <form action="/{{ lang }}/delete_mask/{{ mask.id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="type-name-to-confirm", lang=lang) }}: <strong>{{ mask.name }}</strong></label>
+            <input class="form-control" type="text" name="verify" placeholder="{{ mask.name }}" required>
+        </div>
+        <button class="btn btn-danger" type="submit">{{ fluent(key="delete-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/mask/{{ mask.id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/edit_mask_attack.html
+++ b/templates/masks/edit_mask_attack.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h2>{{ fluent(key="edit-button", lang=lang) }}: {{ mask_attack.name }}</h2>
+    <form action="/{{ lang }}/edit_mask_attack_post/{{ mask_attack.id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="creature-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" value="{{ mask_attack.name }}" required>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="action-step", lang=lang) }}</label>
+            <select class="form-select" name="action_step">
+                {% for step in steps %}
+                <option value="{{ loop.index }}" {% if loop.index == mask_attack.action_step %}selected{% endif %}>{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="effect-step", lang=lang) }}</label>
+            <select class="form-select" name="effect_step">
+                {% for step in steps %}
+                <option value="{{ loop.index }}" {% if loop.index == mask_attack.effect_step %}selected{% endif %}>{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="details", lang=lang) }}</label>
+            <textarea class="form-control" name="details" rows="2">{% if mask_attack.details %}{{ mask_attack.details }}{% endif %}</textarea>
+        </div>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/edit_mask/{{ mask_attack.mask_id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/edit_mask_form.html
+++ b/templates/masks/edit_mask_form.html
@@ -1,0 +1,199 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container" id="{{ mask.id }}-content">
+    <h1>{{ fluent(key="edit-button", lang=lang) }}: {{ mask.name }}</h1>
+    <form action="/{{ lang }}/edit_mask_post/{{ mask.id }}" method="POST">
+
+        <div class="mb-3">
+            <label>{{ fluent(key="mask-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" value="{{ mask.name }}" required>
+        </div>
+
+        <div class="mb-3">
+            <label>{{ fluent(key="mask-description", lang=lang) }}</label>
+            <textarea class="form-control" name="description" rows="3">{{ mask.description }}</textarea>
+        </div>
+
+        <hr>
+        <h4>{{ fluent(key="stat-modifiers", lang=lang) }}</h4>
+        <p class="text-muted">{{ fluent(key="stat-modifiers-help", lang=lang) }}</p>
+
+        <div class="container">
+            <div class="row">
+                <div class="col-sm">
+                    <div class="mb-2">
+                        <label>{{ fluent(key="circle", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="circle_rank" value="{{ mask.circle_rank }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="dexterity", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="dexterity" value="{{ mask.dexterity }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="strength", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="strength" value="{{ mask.strength }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="constitution", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="constitution" value="{{ mask.constitution }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="perception", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="perception" value="{{ mask.perception }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="willpower", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="willpower" value="{{ mask.willpower }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="charisma", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="charisma" value="{{ mask.charisma }}" required>
+                    </div>
+                </div>
+                <div class="col-sm">
+                    <div class="mb-2">
+                        <label>{{ fluent(key="initiative", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="initiative" value="{{ mask.initiative }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="physical-defense", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="pd" value="{{ mask.pd }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="mystic-defense", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="md" value="{{ mask.md }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="social-defense", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="sd" value="{{ mask.sd }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="physical-armor", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="pa" value="{{ mask.pa }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="mystic-armor", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="ma" value="{{ mask.ma }}" required>
+                    </div>
+                </div>
+                <div class="col-sm">
+                    <div class="mb-2">
+                        <label>{{ fluent(key="unconscious-rating", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="unconsciousness_rating" value="{{ mask.unconsciousness_rating }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="death-rating", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="death_rating" value="{{ mask.death_rating }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="wound-rating", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="wound" value="{{ mask.wound }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="knockdown", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="knockdown" value="{{ mask.knockdown }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="actions", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="actions" value="{{ mask.actions }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="recovery-rolls", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="recovery_rolls" value="{{ mask.recovery_rolls }}" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="karma", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="karma" value="{{ mask.karma }}" required>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <hr>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/mask/{{ mask.id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+        <a class="btn btn-danger float-end" href="/{{ lang }}/delete_mask/{{ mask.id }}">{{ fluent(key="delete-button", lang=lang) }}</a>
+    </form>
+</div>
+
+<hr>
+
+<!-- Mask Attacks -->
+<div class="container" id="mask-attacks" hx-target="this" hx-swap="outerHTML">
+    <h3>{{ fluent(key="attacks", lang=lang) }}</h3>
+    {% if mask_attacks %}
+    {% for attack in mask_attacks %}
+    <div id="mask-attack-{{ attack.id }}" hx-target="this" hx-swap="outerHTML">
+        <li>
+            <strong>{{ attack.name }}</strong>: {{ attack.action_step }} ({{ attack.effect_step }}){% if attack.details %}: {{ attack.details }}{% endif %}
+            <a href="/{{ lang }}/edit_mask_attack/{{ attack.id }}" class="btn btn-info btn-sm">{{ fluent(key="edit-button", lang=lang) }}</a>
+            <a href="/{{ lang }}/delete_mask_attack/{{ attack.id }}" class="btn btn-danger btn-sm">{{ fluent(key="delete-button", lang=lang) }}</a>
+        </li>
+    </div>
+    {% endfor %}
+    {% endif %}
+    <br>
+    <a class="btn btn-dark" href="/{{ lang }}/add_mask_attack/{{ mask.id }}">{{ fluent(key="add-an-attack", lang=lang) }}</a>
+    <hr>
+</div>
+
+<!-- Mask Powers -->
+<div class="container" id="mask-powers" hx-target="this" hx-swap="outerHTML">
+    <h3>{{ fluent(key="powers-abilities-spells", lang=lang) }}</h3>
+    {% if mask_powers %}
+    {% for power in mask_powers %}
+    <div id="mask-power-{{ power.id }}" hx-target="this" hx-swap="outerHTML">
+        <li>
+            <strong>{{ power.name }}</strong> ({{ power.action_type }} vs. {{ power.target }}): {{ power.action_step }}{% if power.effect_step %} ({{ power.effect_step }}){% endif %}{% if power.details %}: {{ power.details }}{% endif %}
+            <a href="/{{ lang }}/edit_mask_power/{{ power.id }}" class="btn btn-info btn-sm">{{ fluent(key="edit-button", lang=lang) }}</a>
+            <a href="/{{ lang }}/delete_mask_power/{{ power.id }}" class="btn btn-danger btn-sm">{{ fluent(key="delete-button", lang=lang) }}</a>
+        </li>
+    </div>
+    {% endfor %}
+    {% endif %}
+    <br>
+    <a class="btn btn-dark" href="/{{ lang }}/add_mask_power/{{ mask.id }}">{{ fluent(key="add-power-ability-spell", lang=lang) }}</a>
+    <hr>
+</div>
+
+<!-- Mask Talents -->
+<div class="container" id="mask-talents" hx-target="this" hx-swap="outerHTML">
+    <h3>{{ fluent(key="talents", lang=lang) }}</h3>
+    {% if mask_talents %}
+    {% for talent in mask_talents %}
+    <div id="mask-talent-{{ talent.id }}" hx-target="this" hx-swap="outerHTML">
+        <li>
+            <strong>{{ talent.name }}</strong>: {{ talent.action_step }}
+            <a href="/{{ lang }}/edit_mask_talent/{{ talent.id }}" class="btn btn-info btn-sm">{{ fluent(key="edit-button", lang=lang) }}</a>
+            <a href="/{{ lang }}/delete_mask_talent/{{ talent.id }}" class="btn btn-danger btn-sm">{{ fluent(key="delete-button", lang=lang) }}</a>
+        </li>
+    </div>
+    {% endfor %}
+    {% endif %}
+    <br>
+    <a class="btn btn-dark" href="/{{ lang }}/add_mask_talent/{{ mask.id }}">{{ fluent(key="add-a-talent", lang=lang) }}</a>
+    <hr>
+</div>
+
+<!-- Mask Maneuvers -->
+<div class="container" id="mask-maneuvers" hx-target="this" hx-swap="outerHTML">
+    <h3>{{ fluent(key="special-maneuvers", lang=lang) }}</h3>
+    {% if mask_maneuvers %}
+    {% for maneuver in mask_maneuvers %}
+    <div id="mask-maneuver-{{ maneuver.id }}" hx-target="this" hx-swap="outerHTML">
+        <li>
+            <strong>{{ maneuver.name }}</strong> [{{ maneuver.source }}]: {{ maneuver.details }}
+            <a href="/{{ lang }}/edit_mask_maneuver/{{ maneuver.id }}" class="btn btn-info btn-sm">{{ fluent(key="edit-button", lang=lang) }}</a>
+            <a href="/{{ lang }}/delete_mask_maneuver/{{ maneuver.id }}" class="btn btn-danger btn-sm">{{ fluent(key="delete-button", lang=lang) }}</a>
+        </li>
+    </div>
+    {% endfor %}
+    {% endif %}
+    <br>
+    <a class="btn btn-dark" href="/{{ lang }}/add_mask_maneuver/{{ mask.id }}">Add a Maneuver</a>
+    <hr>
+</div>
+
+{% endblock content %}

--- a/templates/masks/edit_mask_maneuver.html
+++ b/templates/masks/edit_mask_maneuver.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h2>{{ fluent(key="edit-button", lang=lang) }}: {{ mask_maneuver.name }}</h2>
+    <form action="/{{ lang }}/edit_mask_maneuver_post/{{ mask_maneuver.id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="creature-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" value="{{ mask_maneuver.name }}" required>
+        </div>
+        <div class="mb-3">
+            <label>Source</label>
+            <input class="form-control" type="text" name="source" value="{{ mask_maneuver.source }}" required>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="details", lang=lang) }}</label>
+            <textarea class="form-control" name="details" rows="3" required>{{ mask_maneuver.details }}</textarea>
+        </div>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/edit_mask/{{ mask_maneuver.mask_id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/edit_mask_power.html
+++ b/templates/masks/edit_mask_power.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h2>{{ fluent(key="edit-button", lang=lang) }}: {{ mask_power.name }}</h2>
+    <form action="/{{ lang }}/edit_mask_power_post/{{ mask_power.id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="creature-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" value="{{ mask_power.name }}" required>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="action-type", lang=lang) }}</label>
+            <select class="form-select" name="action_type">
+                <option {% if mask_power.action_type == "Free" %}selected{% endif %} value="Free">Free</option>
+                <option {% if mask_power.action_type == "Simple" %}selected{% endif %} value="Simple">Simple</option>
+                <option {% if mask_power.action_type == "Standard" %}selected{% endif %} value="Standard">Standard</option>
+                <option {% if mask_power.action_type == "Move" %}selected{% endif %} value="Move">Move</option>
+                <option {% if mask_power.action_type == "Ritual" %}selected{% endif %} value="Ritual">Ritual</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="target", lang=lang) }}</label>
+            <select class="form-select" name="target">
+                <option {% if mask_power.target == "PhysicalDefense" %}selected{% endif %} value="PhysicalDefense">Physical Defense</option>
+                <option {% if mask_power.target == "MysticDefense" %}selected{% endif %} value="MysticDefense">Mystic Defense</option>
+                <option {% if mask_power.target == "SocialDefense" %}selected{% endif %} value="SocialDefense">Social Defense</option>
+                <option {% if mask_power.target == "TN6" %}selected{% endif %} value="TN6">TN 6</option>
+                <option {% if mask_power.target == "TN10" %}selected{% endif %} value="TN10">TN 10</option>
+                <option {% if mask_power.target == "Other" %}selected{% endif %} value="Other">Other</option>
+                <option {% if mask_power.target == "NotApplicable" %}selected{% endif %} value="NotApplicable">Not Applicable</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="resisted-by", lang=lang) }}</label>
+            <select class="form-select" name="resisted_by">
+                <option {% if mask_power.resisted_by == "Physical" %}selected{% endif %} value="Physical">Physical</option>
+                <option {% if mask_power.resisted_by == "Mystic" %}selected{% endif %} value="Mystic">Mystic</option>
+                <option {% if mask_power.resisted_by == "Other" %}selected{% endif %} value="Other">Other</option>
+                <option {% if mask_power.resisted_by == "NotApplicable" %}selected{% endif %} value="NotApplicable">Not Applicable</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="action-step", lang=lang) }}</label>
+            <select class="form-select" name="action_step">
+                {% for step in steps %}
+                <option value="{{ loop.index }}" {% if loop.index == mask_power.action_step %}selected{% endif %}>{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="effect-step", lang=lang) }}</label>
+            <select class="form-select" name="effect_step">
+                <option value="">None</option>
+                {% for step in steps %}
+                <option value="{{ loop.index }}" {% if mask_power.effect_step and loop.index == mask_power.effect_step %}selected{% endif %}>{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="details", lang=lang) }}</label>
+            <textarea class="form-control" name="details" rows="2">{% if mask_power.details %}{{ mask_power.details }}{% endif %}</textarea>
+        </div>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/edit_mask/{{ mask_power.mask_id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/edit_mask_talent.html
+++ b/templates/masks/edit_mask_talent.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h2>{{ fluent(key="edit-button", lang=lang) }}: {{ mask_talent.name }}</h2>
+    <form action="/{{ lang }}/edit_mask_talent_post/{{ mask_talent.id }}" method="POST">
+        <div class="mb-3">
+            <label>{{ fluent(key="creature-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" value="{{ mask_talent.name }}" required>
+        </div>
+        <div class="mb-3">
+            <label>{{ fluent(key="action-step", lang=lang) }}</label>
+            <select class="form-select" name="action_step">
+                {% for step in steps %}
+                <option value="{{ loop.index }}" {% if loop.index == mask_talent.action_step %}selected{% endif %}>{{ step }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/edit_mask/{{ mask_talent.mask_id }}">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+</div>
+
+{% endblock content %}

--- a/templates/masks/mask.html
+++ b/templates/masks/mask.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h1>{{ mask.name }}</h1>
+    {% if mask.description %}
+    <p>{{ mask.description }}</p>
+    {% endif %}
+    <p><small class="text-muted">{{ fluent(key="created-by", lang=lang) }}: {{ mask.creator_slug }}</small></p>
+
+    {% if session_user == mask.creator_slug or role == "Admin" %}
+    <a class="btn btn-secondary btn-sm" href="/{{ lang }}/edit_mask/{{ mask.id }}">{{ fluent(key="edit-button", lang=lang) }}</a>
+    <a class="btn btn-danger btn-sm" href="/{{ lang }}/delete_mask/{{ mask.id }}">{{ fluent(key="delete-button", lang=lang) }}</a>
+    {% endif %}
+
+    <hr>
+
+    <h2>{{ fluent(key="stat-modifiers", lang=lang) }}</h2>
+    <div class="container">
+        <div class="row">
+            <div class="col-sm">
+                <table class="table table-sm">
+                    <tbody>
+                        {% if mask.circle_rank != 0 %}<tr><td>{{ fluent(key="circle", lang=lang) }}</td><td>{% if mask.circle_rank > 0 %}+{% endif %}{{ mask.circle_rank }}</td></tr>{% endif %}
+                        {% if mask.dexterity != 0 %}<tr><td>{{ fluent(key="dexterity", lang=lang) }}</td><td>{% if mask.dexterity > 0 %}+{% endif %}{{ mask.dexterity }}</td></tr>{% endif %}
+                        {% if mask.strength != 0 %}<tr><td>{{ fluent(key="strength", lang=lang) }}</td><td>{% if mask.strength > 0 %}+{% endif %}{{ mask.strength }}</td></tr>{% endif %}
+                        {% if mask.constitution != 0 %}<tr><td>{{ fluent(key="constitution", lang=lang) }}</td><td>{% if mask.constitution > 0 %}+{% endif %}{{ mask.constitution }}</td></tr>{% endif %}
+                        {% if mask.perception != 0 %}<tr><td>{{ fluent(key="perception", lang=lang) }}</td><td>{% if mask.perception > 0 %}+{% endif %}{{ mask.perception }}</td></tr>{% endif %}
+                        {% if mask.willpower != 0 %}<tr><td>{{ fluent(key="willpower", lang=lang) }}</td><td>{% if mask.willpower > 0 %}+{% endif %}{{ mask.willpower }}</td></tr>{% endif %}
+                        {% if mask.charisma != 0 %}<tr><td>{{ fluent(key="charisma", lang=lang) }}</td><td>{% if mask.charisma > 0 %}+{% endif %}{{ mask.charisma }}</td></tr>{% endif %}
+                    </tbody>
+                </table>
+            </div>
+            <div class="col-sm">
+                <table class="table table-sm">
+                    <tbody>
+                        {% if mask.initiative != 0 %}<tr><td>{{ fluent(key="initiative", lang=lang) }}</td><td>{% if mask.initiative > 0 %}+{% endif %}{{ mask.initiative }}</td></tr>{% endif %}
+                        {% if mask.pd != 0 %}<tr><td>{{ fluent(key="physical-defense", lang=lang) }}</td><td>{% if mask.pd > 0 %}+{% endif %}{{ mask.pd }}</td></tr>{% endif %}
+                        {% if mask.md != 0 %}<tr><td>{{ fluent(key="mystic-defense", lang=lang) }}</td><td>{% if mask.md > 0 %}+{% endif %}{{ mask.md }}</td></tr>{% endif %}
+                        {% if mask.sd != 0 %}<tr><td>{{ fluent(key="social-defense", lang=lang) }}</td><td>{% if mask.sd > 0 %}+{% endif %}{{ mask.sd }}</td></tr>{% endif %}
+                        {% if mask.pa != 0 %}<tr><td>{{ fluent(key="physical-armor", lang=lang) }}</td><td>{% if mask.pa > 0 %}+{% endif %}{{ mask.pa }}</td></tr>{% endif %}
+                        {% if mask.ma != 0 %}<tr><td>{{ fluent(key="mystic-armor", lang=lang) }}</td><td>{% if mask.ma > 0 %}+{% endif %}{{ mask.ma }}</td></tr>{% endif %}
+                    </tbody>
+                </table>
+            </div>
+            <div class="col-sm">
+                <table class="table table-sm">
+                    <tbody>
+                        {% if mask.unconsciousness_rating != 0 %}<tr><td>{{ fluent(key="unconscious-rating", lang=lang) }}</td><td>{% if mask.unconsciousness_rating > 0 %}+{% endif %}{{ mask.unconsciousness_rating }}</td></tr>{% endif %}
+                        {% if mask.death_rating != 0 %}<tr><td>{{ fluent(key="death-rating", lang=lang) }}</td><td>{% if mask.death_rating > 0 %}+{% endif %}{{ mask.death_rating }}</td></tr>{% endif %}
+                        {% if mask.wound != 0 %}<tr><td>{{ fluent(key="wound-rating", lang=lang) }}</td><td>{% if mask.wound > 0 %}+{% endif %}{{ mask.wound }}</td></tr>{% endif %}
+                        {% if mask.knockdown != 0 %}<tr><td>{{ fluent(key="knockdown", lang=lang) }}</td><td>{% if mask.knockdown > 0 %}+{% endif %}{{ mask.knockdown }}</td></tr>{% endif %}
+                        {% if mask.actions != 0 %}<tr><td>{{ fluent(key="actions", lang=lang) }}</td><td>{% if mask.actions > 0 %}+{% endif %}{{ mask.actions }}</td></tr>{% endif %}
+                        {% if mask.recovery_rolls != 0 %}<tr><td>{{ fluent(key="recovery-rolls", lang=lang) }}</td><td>{% if mask.recovery_rolls > 0 %}+{% endif %}{{ mask.recovery_rolls }}</td></tr>{% endif %}
+                        {% if mask.karma != 0 %}<tr><td>{{ fluent(key="karma", lang=lang) }}</td><td>{% if mask.karma > 0 %}+{% endif %}{{ mask.karma }}</td></tr>{% endif %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    {% if mask_attacks %}
+    <hr>
+    <h3>{{ fluent(key="attacks", lang=lang) }}</h3>
+    <ul>
+        {% for attack in mask_attacks %}
+        <li><strong>{{ attack.name }}</strong>: {{ attack.action_step }} ({{ attack.effect_step }}){% if attack.details %}: {{ attack.details }}{% endif %}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    {% if mask_powers %}
+    <hr>
+    <h3>{{ fluent(key="powers-abilities-spells", lang=lang) }}</h3>
+    <ul>
+        {% for power in mask_powers %}
+        <li><strong>{{ power.name }}</strong> ({{ power.action_type }} vs. {{ power.target }}): {{ power.action_step }}{% if power.effect_step %} ({{ power.effect_step }}){% endif %}{% if power.details %}: {{ power.details }}{% endif %}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    {% if mask_talents %}
+    <hr>
+    <h3>{{ fluent(key="talents", lang=lang) }}</h3>
+    <ul>
+        {% for talent in mask_talents %}
+        <li><strong>{{ talent.name }}</strong>: {{ talent.action_step }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    {% if mask_maneuvers %}
+    <hr>
+    <h3>{{ fluent(key="special-maneuvers", lang=lang) }}</h3>
+    <ul>
+        {% for maneuver in mask_maneuvers %}
+        <li><strong>{{ maneuver.name }}</strong> [{{ maneuver.source }}]: {{ maneuver.details }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>
+
+{% endblock content %}

--- a/templates/masks/masks.html
+++ b/templates/masks/masks.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <div class="row">
+        <h1>{{ fluent(key="masks", lang=lang) }}</h1>
+    </div>
+
+    {% if session_user != "" %}
+    <div class="row mb-3">
+        <a class="btn btn-primary" href="/{{ lang }}/new_mask_form">{{ fluent(key="new-mask", lang=lang) }}</a>
+    </div>
+    {% endif %}
+
+    {% if masks %}
+    <div class="row">
+        {% for mask in masks %}
+        <div class="col-md-4 mb-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">{{ mask.name }}</h5>
+                    {% if mask.description %}
+                    <p class="card-text">{{ mask.description | truncate(length=100) }}</p>
+                    {% endif %}
+                    <p class="card-text"><small class="text-muted">Circle {{ mask.circle_rank > 0 }} | By {{ mask.creator_slug }}</small></p>
+                    <a href="/{{ lang }}/mask/{{ mask.id }}" class="btn btn-info btn-sm">{{ fluent(key="view-button", lang=lang) }}</a>
+                    {% if session_user == mask.creator_slug or role == "Admin" %}
+                    <a href="/{{ lang }}/edit_mask/{{ mask.id }}" class="btn btn-secondary btn-sm">{{ fluent(key="edit-button", lang=lang) }}</a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <p>{{ fluent(key="no-masks", lang=lang) }}</p>
+    {% endif %}
+</div>
+
+{% endblock content %}

--- a/templates/masks/new_mask_form.html
+++ b/templates/masks/new_mask_form.html
@@ -1,0 +1,124 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container">
+    <h1>{{ fluent(key="new-mask", lang=lang) }}</h1>
+    <form action="/{{ lang }}/post_mask" method="POST">
+
+        <div class="mb-3">
+            <label>{{ fluent(key="mask-name", lang=lang) }}</label>
+            <input class="form-control" type="text" name="name" placeholder="Mask name..." required>
+        </div>
+
+        <div class="mb-3">
+            <label>{{ fluent(key="mask-description", lang=lang) }}</label>
+            <textarea class="form-control" name="description" rows="3" placeholder="Describe what this mask represents..."></textarea>
+        </div>
+
+        <hr>
+        <h4>{{ fluent(key="stat-modifiers", lang=lang) }}</h4>
+        <p class="text-muted">{{ fluent(key="stat-modifiers-help", lang=lang) }}</p>
+
+        <div class="container">
+            <div class="row">
+                <div class="col-sm">
+                    <div class="mb-2">
+                        <label>{{ fluent(key="circle", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="circle_rank" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="dexterity", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="dexterity" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="strength", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="strength" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="constitution", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="constitution" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="perception", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="perception" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="willpower", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="willpower" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="charisma", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="charisma" value="0" required>
+                    </div>
+                </div>
+                <div class="col-sm">
+                    <div class="mb-2">
+                        <label>{{ fluent(key="initiative", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="initiative" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="physical-defense", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="pd" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="mystic-defense", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="md" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="social-defense", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="sd" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="physical-armor", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="pa" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="mystic-armor", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="ma" value="0" required>
+                    </div>
+                </div>
+                <div class="col-sm">
+                    <div class="mb-2">
+                        <label>{{ fluent(key="unconscious-rating", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="unconsciousness_rating" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="death-rating", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="death_rating" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="wound-rating", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="wound" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="knockdown", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="knockdown" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="actions", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="actions" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="recovery-rolls", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="recovery_rolls" value="0" required>
+                    </div>
+                    <div class="mb-2">
+                        <label>{{ fluent(key="karma", lang=lang) }}</label>
+                        <input class="form-control" type="number" name="karma" value="0" required>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <hr>
+        <button class="btn btn-primary" type="submit">{{ fluent(key="save-button", lang=lang) }}</button>
+        <a class="btn btn-secondary" href="/{{ lang }}/masks">{{ fluent(key="cancel-button", lang=lang) }}</a>
+    </form>
+
+    <div class="mt-3">
+        <p class="text-muted">{{ fluent(key="add-mask-items-after-save", lang=lang) }}</p>
+    </div>
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
Adds a Mask system allowing users to create reusable templates that
modify creature stats and attach attacks, powers, talents, and maneuvers.

Key changes:
- New database migration creating masks, mask_attacks, mask_powers,
  mask_talents, and mask_maneuvers tables with CASCADE deletes
- Full Diesel models for Mask and all related sub-items (MaskAttack,
  MaskPower, MaskTalent, MaskManeuver) with CRUD methods
- Mask handler with complete CRUD routes for masks and all sub-items
- Mask templates: list, view, create, edit, delete forms
- Templates for adding/editing mask attacks, powers, talents, maneuvers
- Updated creature create/edit forms with mask selector dropdown
- Mask application in post_creature and edit_creature_post handlers:
  stat deltas are applied additively to form values, and mask items are
  copied to the creature as attacks/powers/talents/maneuvers
- i18n keys for masks in English and French
- Masks navigation link added to navbar
- schema.rs updated with mask table definitions and join relations

https://claude.ai/code/session_01EadLTP68sQxuWgbFbZZdaR